### PR TITLE
Update reference to default branch

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -26,7 +26,7 @@ end
 class CustomVersionParser
   def self.call(string_version)
     case string_version
-    when "master", /\Abranch-/
+    when "main", /\Abranch-/
       Version.new(string_version)
     else
       Version.new(::Versionomy.parse(string_version))


### PR DESCRIPTION
We are updating it to `main`.

https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main