### PR TITLE
Rewrite README to incorporate versioning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repo is a thin wrapper around the [Pact Broker Gem][pact-broker-gem] that
 allows Pact Broker to be run on unicorn server on the
-[Government PAAS][government-paas].
+[GOV.UK PAAS][government-paas].
 
 It is used by projects such as [Publishing API][publishing-api],
 [GDS API Adapters][gds-api-adapters] and [Content Store][content-store] for
 contract testing.
 
-## Run this locally
+## Getting started
 
 ### Install dependencies
 
@@ -39,81 +39,10 @@ $ export DATABASE_URL=postgresql://pact_broker@localhost/pact_broker
 $ bundle exec unicorn
 ```
 
-## Deploy a change to the PAAS
+## Further documentation
 
-You'll need a cloud foundry account for [Government PAAS][government-paas] and
-be in the `govuk_development` organisation with access to the `sandbox` space.
-
-From there you should be able to see this app (`pact-broker`) by running:
-
-```
-$ cf apps
-```
-
-Then when you have made your changes you can push a new deployment with:
-
-```
-$ cf push pact-broker
-```
-
-## Run this on the [Government PAAS][government-paas]
-
-### Space for the app
-
-You may be given a space by your organisation manager, or need to create one
-for the application.
-
-At the time of writing this app runs on the `govuk_development` organisation
-in the `sandbox` space
-
-### Push the app to the PAAS
-
-As we've not set everything up we don't want to start the app now.
-
-```
-$ cf push pact-broker --no-start
-```
-
-we can pass a `-n HOSTNAME` argument here to specify the hostname, otherwise
-it will use the default one of `pact-broker` (as specified in
-[manifest.yml](manifest.yml))
-
-### Create a database
-
-There's a number of different database plans available, but the "Free" one
-should be sufficient:
-
-```
-$ cf create-service postgres Free pact-broker-db
-```
-
-This will take a few minutes. Once completed it can be bound to the application:
-
-```
-$ cf bind-service pact-broker pact-broker-db
-```
-
-### Set up environment variables for credentials
-
-This application requires basic auth credentials of `AUTH_USERNAME` and
-`AUTH_PASSWORD`.
-
-```
-$ cf set-env pact-broker AUTH_USERNAME username
-$ cf set-env pact-broker AUTH_PASSWORD password
-```
-
-### Start the app
-
-```
-$ cf start pact-broker
-```
-
-And then you'll probably want it to run on 2 instances:
-
-```
-$ cf scale pact-broker -i 2
-```
+- [Infrastructure](docs/infrastructure.md)
+- [Deployment](docs/deployment.md)
 
 [pact-broker-gem]: https://github.com/bethesque/pact_broker
 [government-paas]: https://docs.cloud.service.gov.uk/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ bundle exec unicorn
 
 - [Infrastructure](docs/infrastructure.md)
 - [Deployment](docs/deployment.md)
+- [Versioning](docs/versioning.md)
 
 [pact-broker-gem]: https://github.com/bethesque/pact_broker
 [government-paas]: https://docs.cloud.service.gov.uk/

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,18 @@
+# Deployment
+
+You'll need a cloud foundry account for [GOV.UK PAAS][government-paas] and
+be in the `govuk_development` organisation with access to the `sandbox` space.
+
+From there you should be able to see this app (`pact-broker`) by running:
+
+```
+$ cf apps
+```
+
+Then when you have made your changes you can push a new deployment with:
+
+```
+$ cf push pact-broker
+```
+
+[government-paas]: https://docs.cloud.service.gov.uk/

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,0 +1,62 @@
+# Infrastructure
+
+This app is deployed on [GOV.UK PAAS][government-paas].
+
+## Space for the app
+
+You may be given a space by your organisation manager, or need to create one
+for the application.
+
+At the time of writing this app runs on the `govuk_development` organisation
+in the `sandbox` space
+
+## Push the app to the PAAS
+
+As we've not set everything up we don't want to start the app now.
+
+```
+$ cf push pact-broker --no-start
+```
+
+we can pass a `-n HOSTNAME` argument here to specify the hostname, otherwise
+it will use the default one of `pact-broker` (as specified in
+[manifest.yml](manifest.yml))
+
+## Create a database
+
+There's a number of different database plans available, but the "Free" one
+should be sufficient:
+
+```
+$ cf create-service postgres Free pact-broker-db
+```
+
+This will take a few minutes. Once completed it can be bound to the application:
+
+```
+$ cf bind-service pact-broker pact-broker-db
+```
+
+## Set up environment variables for credentials
+
+This application requires basic auth credentials of `AUTH_USERNAME` and
+`AUTH_PASSWORD`.
+
+```
+$ cf set-env pact-broker AUTH_USERNAME username
+$ cf set-env pact-broker AUTH_PASSWORD password
+```
+
+## Start the app
+
+```
+$ cf start pact-broker
+```
+
+And then you'll probably want it to run on 2 instances:
+
+```
+$ cf scale pact-broker -i 2
+```
+
+[government-paas]: https://docs.cloud.service.gov.uk/

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure
 
-This app is deployed on [GOV.UK PAAS][government-paas].
+This guidance is about how to setup the app from scratch on [GOV.UK PAAS][government-paas].
 
 ## Space for the app
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,15 +2,15 @@
 
 Out of the box, the Pact Broker allows uploading of pact files with semver
 style versions (eg 2.0.1). For our usage, we wanted to be able to upload pact
-files from various branches in addition the released versions so that our
-branch builds of consumers can verify their pactfiles with the producers.
+files from various branches in addition to the released versions so that our
+branch builds of consumers can verify their pactfiles with the providers.
 
 Pact Broker allows us to [implement our own versioning
 scheme](https://github.com/bethesque/pact_broker/wiki/Configuration#version-parser)
-by providing a custom version parser.  We've [used
-this](https://github.com/alphagov/govuk-pact-broker/blob/master/config.ru#L23-L50)
+by providing a custom version parser. We've [used
+this](https://github.com/alphagov/govuk-pact-broker/blob/main/config.ru#L23-L50)
 to extend the versioning scheme to allow branch builds to be uploaded as well.
-In addition to numeric versions, our scheme allows for "master", and
+In addition to numeric versions, our scheme allows for "main", and
 "branch-foo" versions to be uploaded. These will always be ordered after any
-numeric versions, so the 'latest' pactfile from the pact brokers POV will
+numeric versions, so the 'latest' pactfile from the Pact Broker's point of view will
 always be the highest numeric version.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,16 @@
+# Versioning
+
+Out of the box, the Pact Broker allows uploading of pact files with semver
+style versions (eg 2.0.1). For our usage, we wanted to be able to upload pact
+files from various branches in addition the released versions so that our
+branch builds of consumers can verify their pactfiles with the producers.
+
+Pact Broker allows us to [implement our own versioning
+scheme](https://github.com/bethesque/pact_broker/wiki/Configuration#version-parser)
+by providing a custom version parser.  We've [used
+this](https://github.com/alphagov/govuk-pact-broker/blob/master/config.ru#L23-L50)
+to extend the versioning scheme to allow branch builds to be uploaded as well.
+In addition to numeric versions, our scheme allows for "master", and
+"branch-foo" versions to be uploaded. These will always be ordered after any
+numeric versions, so the 'latest' pactfile from the pact brokers POV will
+always be the highest numeric version.


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This tidies up the README a bit to provide a structure
for adding further guidance about the versioning scheme
used by this fork of Pact Broker.

Please see the commits for more details.