### PR TITLE
Rather than a custom logger, just specify logs go to stdout

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -54,7 +54,7 @@ app = PactBroker::App.new do | config |
   # config.log_dir = "./log"
   # config.auto_migrate_db = true
   # config.use_hal_browser = true
-  config.logger = Logger.new($stdout)
+  config.log_stream = "stdout"
 
   # Have a look at the Sequel documentation to make decisions about things like connection pooling
   # and connection validation.


### PR DESCRIPTION
This change has been done to fix an instance where pact-broker crashes
whenever data is written to it due to the Ruby Logger class not having
the same method signature as the logger used by pact-broker. Stack trace
provided below.

We only used a custom logger as a means to send logs to STDOUT and this
can be achieved by a configuration option [1].

Stack trace:

```
  2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT I, [2022-05-09T11:30:41.050163 #107]  INFO -- : (0.000396s) SELECT "pact_publications".* FROM (SELECT * FROM "pact_publications" WHERE (("consumer_version_id" = 1772) AND ("provider_id" = 1))) AS "pact_publications" INNER JOIN "latest_pact_publication_ids_for_consumer_versions" AS "lp" ON ("lp"."pact_publication_id" = "pact_publications"."id") LIMIT 1
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT E, [2022-05-09T11:30:41.050482 #107] ERROR -- : Error reference BRnvrpsMBy - ArgumentError unknown keyword: :payload
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/ruby/lib/ruby/2.7.0/logger.rb:527:in `info'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/pacts/service.rb:188:in `create_pact'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/pacts/service.rb:61:in `create_or_update_pact'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:141:in `block in create_or_merge_pact'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/events/subscriber.rb:37:in `block in subscribe'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/events/subscriber.rb:14:in `subscribe'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/wisper-2.0.1/lib/wisper/temporary_listeners.rb:8:in `subscribe'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/events/subscriber.rb:36:in `subscribe'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:137:in `create_or_merge_pact'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:116:in `block in create_pacts'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:112:in `collect'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:112:in `create_pacts'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/contracts/service.rb:35:in `publish'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/api/resources/publish_contracts.rb:87:in `block in publish_contracts'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/api/resources/webhook_execution_methods.rb:11:in `block in handle_webhook_events'
   2022-05-09T11:30:41.05+0000 [APP/PROC/WEB/0] OUT /home/vcap/deps/0/vendor_bundle/ruby/2.7.0/gems/pact_broker-2.98.0/lib/pact_broker/events/subscriber.rb:37:in `block in subscribe'
   ```

[1]: https://docs.pact.io/pact_broker/configuration/settings#log_stream