### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ $ bundle exec unicorn
 [publishing-api]: https://github.com/alphagov/publishing-api
 [gds-api-adapters]: https://github.com/alphagov/gds-api-adapters
 [content-store]: https://github.com/alphagov/content-store
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence