### PR TITLE
Add configuration to get Pact Broker running on Heroku

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM pactfoundation/pact-broker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM pactfoundation/pact-broker
+FROM pactfoundation/pact-broker:2.112.0-pactbroker2.107.1

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ This repo is a thin wrapper around the [Pact Broker Gem][pact-broker-gem] that
 allows Pact Broker to be run on unicorn server on the
 [GOV.UK PAAS][government-paas].
 
-It is used by projects such as [Publishing API][publishing-api],
+As PaaS is being decommissioned later this year, we are currently migrating
+Pact Broker to Heroku, and so this repo also contains a `Dockerfile` and
+associated `heroku.yml` file to allow it to run there. After the migration is
+complete, the leftover pieces of the old wrapper (`config.ru`, `Gemfile`,
+`Procfile`, etc.) will be removed from this repo.
+
+Pact Broker is used by projects such as [Publishing API][publishing-api],
 [GDS API Adapters][gds-api-adapters] and [Content Store][content-store] for
 contract testing.
 
-## Getting started
+## Getting started (legacy version)
 
 ### Install dependencies
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment
 
+## Legacy instance (on PaaS)
+
 You'll need a cloud foundry account for [GOV.UK PAAS][government-paas] and
 be in the `govuk_development` organisation with access to the `sandbox` space.
 
@@ -16,3 +18,8 @@ $ cf push pact-broker
 ```
 
 [government-paas]: https://docs.cloud.service.gov.uk/
+
+## New instance (on Heroku)
+
+This instance is automatically deployed whenever a new commit is pushed.
+Logs can be found in [the Heroku dashboard for this project](https://dashboard.heroku.com/apps/govuk-pact-broker).

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
[Trello card](https://trello.com/c/HBe0RqvA/3335-get-a-new-instance-of-pact-broker-running-on-heroku)

We're moving Pact Broker from PaaS (which is being decommissioned soon) to Heroku. This PR adds initial configuration for this, and updates our readme and documentation accordingly.

Older versions of Pact Broker parsed version numbers in order to determine the order to display pacts in, and so our old wrapper script includes a [custom version parser](https://github.com/alphagov/govuk-pact-broker/blob/e2a3d5281c540d1815fdf57d4a81577fe9e2fc5f/config.ru#L26-L50) so that this ordering wouldn't break if we used non-numeric version numbers (for example, branch names). Sorting pacts by version [was deprecated a while ago](https://docs.pact.io/pact_broker/configuration/features#ordering-versions), and pacts are instead sorted by date now, so I don't _think_ we need this logic anymore. I guess we'll see what happens when we start pointing our repos at this new instance!